### PR TITLE
Python3 fix, file() -> open()

### DIFF
--- a/po2json/__init__.py
+++ b/po2json/__init__.py
@@ -9,7 +9,7 @@ from babel.messages.pofile import read_po
 
 try:
     import simplejson as json
-except ImportError: 
+except ImportError:
     import json
 
 
@@ -22,7 +22,7 @@ def compile_to_js(po_file, lang, domain):
 
     jscatalog = {}
 
-    with file(po_file) as f:
+    with open(po_file) as f:
         catalog = read_po(f, locale=lang, domain=domain)
 
         for message in catalog:


### PR DESCRIPTION
Using the file() constructor in python3 is no longer supported. Changing for open().

https://docs.python.org/2/library/functions.html#file

> When opening a file, it’s preferable to use open() instead of invoking this constructor directly. file is more suited to type testing (for example, writing isinstance(f, file)).
